### PR TITLE
Stub Caching

### DIFF
--- a/frontend/src/Effect.elm
+++ b/frontend/src/Effect.elm
@@ -6,7 +6,7 @@ port module Effect exposing
     , pushRoutePath, replaceRoutePath
     , loadExternalUrl, back
     , map, toCmd
-    , addDesignsToDownload, downloadFile, removeDesignsFromDownload, renderVegaPlot, resetViewport, resizeShared
+    , addDesignsToDownload, downloadFile, removeDesignsFromDownload, renderVegaPlot, resetViewport, resizeShared, saveDesignStubs
     )
 
 {-|
@@ -27,10 +27,9 @@ port module Effect exposing
 import Browser.Dom as Dom
 import Browser.Navigation
 import Dict exposing (Dict)
-import File exposing (File)
 import File.Download as Download
 import Plots exposing (PlotData)
-import ProteinDesign exposing (DownloadFileType)
+import ProteinDesign exposing (DownloadFileType, ProteinDesignStub)
 import Route
 import Route.Path
 import Shared.Model
@@ -171,6 +170,15 @@ resetViewport msg =
 resizeShared : Int -> Int -> Effect msg
 resizeShared width height =
     ResizeShared width height
+
+
+
+-- CACHE
+
+
+saveDesignStubs : Dict String ProteinDesignStub -> Effect msg
+saveDesignStubs stubs =
+    SendSharedMsg (Shared.Msg.SaveDesignStubs stubs)
 
 
 

--- a/frontend/src/Shared.elm
+++ b/frontend/src/Shared.elm
@@ -49,6 +49,7 @@ type alias Model =
 init : Result Json.Decode.Error Flags -> Route () -> ( Model, Effect Msg )
 init _ _ =
     ( { designs = NotAsked
+      , designStubs = Nothing
       , errors = []
       , designsToDownload = Set.empty
       , mScreenWidthF = Nothing
@@ -77,6 +78,11 @@ update _ msg model =
                         |> Dict.fromList
             in
             ( { model | designs = Success designs }
+            , Effect.none
+            )
+
+        SaveDesignStubs designStubs ->
+            ( { model | designStubs = Just designStubs }
             , Effect.none
             )
 

--- a/frontend/src/Shared/Model.elm
+++ b/frontend/src/Shared/Model.elm
@@ -6,7 +6,7 @@ import AppError exposing (AppError)
 import Dict exposing (Dict)
 import Element exposing (..)
 import Http
-import ProteinDesign exposing (ProteinDesign)
+import ProteinDesign exposing (ProteinDesign, ProteinDesignStub)
 import RemoteData exposing (RemoteData)
 import Set exposing (Set)
 
@@ -20,6 +20,7 @@ own file, so they can be imported by `Effect.elm`
 -}
 type alias Model =
     { designs : RemoteData Http.Error (Dict String ProteinDesign)
+    , designStubs : Maybe (Dict String ProteinDesignStub)
     , errors : List AppError
     , designsToDownload : Set String
     , mScreenWidthF : Maybe Float

--- a/frontend/src/Shared/Msg.elm
+++ b/frontend/src/Shared/Msg.elm
@@ -1,8 +1,9 @@
 module Shared.Msg exposing (Msg(..))
 
 import Browser.Dom
+import Dict exposing (Dict)
 import Http
-import ProteinDesign exposing (ProteinDesign)
+import ProteinDesign exposing (ProteinDesign, ProteinDesignStub)
 
 
 {-| Normally, this value would live in "Shared.elm"
@@ -14,6 +15,7 @@ own file, so they can be imported by `Effect.elm`
 -}
 type Msg
     = DesignsDataReceived (Result Http.Error (List ProteinDesign))
+    | SaveDesignStubs (Dict String ProteinDesignStub)
     | AddDesignsToDownload (List String)
     | RemoveDesignsFromDownload (List String)
     | WindowResizes Int Int


### PR DESCRIPTION
Now caches design stubs and will reuse them when the user clicks back.